### PR TITLE
added bysetpos validation to prevent endless looping

### DIFF
--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -327,15 +327,9 @@ ICAL.RecurIterator = (function() {
         return null;
       }
 
-      // if there are no possible valid events return null.
-      try {
-        if (this.has_invalid_bysetpos()) {
-          return null;
-        }
-      } catch (err) {
-       // do nothing.
+      if (this.has_invalid_bysetpos()) {
+        return null;
       }
-
 
       if (this.occurrence_number == 0 && this.last.compare(this.dtstart) >= 0) {
         // First of all, give the instance that was initialized
@@ -365,12 +359,17 @@ ICAL.RecurIterator = (function() {
           this.next_week();
           break;
         case "MONTHLY":
+          if (this.has_invalid_bysetpos(5)) {
+            return null;
+          }
           valid = this.next_month();
           break;
         case "YEARLY":
+          if (this.has_invalid_bysetpos(53)) {
+            return null;
+          }
           this.next_year();
           break;
-
         default:
           return null;
         }
@@ -419,37 +418,39 @@ ICAL.RecurIterator = (function() {
       this.increment_generic(inc, "hour", 24, "monthday");
     },
 
-    get_number_of_days_in_frequency: function get_number_of_days_in_frequency() {
-      // There is a maximum of 53 of any given day in a year,
-      // and 5 in a month. i.e. there cannot be more than 5 Sundays in 1 month.
-      return this.rule.freq === "YEARLY" ? 53 : 5;
-    },
-
-    get_max_number_of_possible_byday_values: function get_number_of_possible_byday_values() {
+    get_max_number_of_possible_byday_values: function get_number_of_possible_byday_values(days_in_timeslice) {
       var self = this;
       var reducer = function(acc, value) {
-        return acc + Math.floor(self.get_number_of_days_in_frequency() / self.ruleDayOfWeek(value)[0]);
+        return acc + Math.floor(days_in_timeslice / self.ruleDayOfWeek(value)[0]);
       };
       return this.by_data.BYDAY.reduce(reducer, 0);
     },
 
-    has_invalid_bysetpos: function has_invalid_bysetpos() {
-      if (!this.by_data.BYDAY || this.by_data.BYDAY.length < 1) {
-        return false;
-      }
-
-      if (!this.by_data.BYSETPOS || this.by_data.BYSETPOS.length < 1) {
-        return false;
-      }
-
-      var max_number_of_possible_days = this.get_max_number_of_possible_byday_values();
-      var checker = function(acc, value) {
-        if (acc) {
-          return acc;
+    does_any_value_exceed_max_days: function does_any_value_exceed_max_days(values, max_number_of_possible_days) {
+      for (var value of values) {
+        if (value > max_number_of_possible_days) {
+          return true;
         }
-        return value > max_number_of_possible_days;
-      };
-      return this.by_data.BYSETPOS.reduce(checker, false);
+      }
+      return false;
+    },
+
+    has_invalid_bysetpos: function has_invalid_bysetpos(days_in_timeslice) {
+      try { 
+        if (!this.by_data.BYDAY || this.by_data.BYDAY.length < 1) {
+          return false;
+        }
+  
+        if (!this.by_data.BYSETPOS || this.by_data.BYSETPOS.length < 1) {
+          return false;
+        }
+  
+        var max_number_of_possible_days = this.get_max_number_of_possible_byday_values(days_in_timeslice);
+        
+        return this.does_any_value_exceed_max_days(this.by_data.BYSETPOS, max_number_of_possible_days);
+      } catch (err) {
+        return false;
+      }
     },
 
     next_day: function next_day() {

--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -436,11 +436,11 @@ ICAL.RecurIterator = (function() {
     },
 
     does_any_value_exceed_max_days: function does_any_value_exceed_max_days(values, max_number_of_possible_days) {
-      for (var value of values) {
-        if (value > max_number_of_possible_days) {
+      for (var i = 0; i < values.length; i++) {
+        if (values[i] > max_number_of_possible_days) {
           return true;
         }
-      }
+      };
       return false;
     },
 

--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -211,6 +211,19 @@ ICAL.RecurIterator = (function() {
         throw new Error("BYYEARDAY may only appear in YEARLY rules");
       }
 
+      // I've turned this off because there's weird behaviour where the recur iterator completely ignores BYSETPOS :thinking:
+      // if (this.rule.freq == "YEARLY") {
+      //   if (this.has_invalid_bysetpos(53)) {
+      //     throw new Error("Yearly BYSETPOS value larger than max count of viable events");
+      //   }
+      // }
+
+      if (this.rule.freq == "MONTHLY") {
+        if (this.has_invalid_bysetpos(5)) {
+          throw new Error("Monthly BYSETPOS value larger than max count of viable events");
+        }
+      }
+      
       this.last.second = this.setup_defaults("BYSECOND", "SECONDLY", this.dtstart.second);
       this.last.minute = this.setup_defaults("BYMINUTE", "MINUTELY", this.dtstart.minute);
       this.last.hour = this.setup_defaults("BYHOUR", "HOURLY", this.dtstart.hour);
@@ -355,15 +368,9 @@ ICAL.RecurIterator = (function() {
           this.next_week();
           break;
         case "MONTHLY":
-          if (this.has_invalid_bysetpos(5)) {
-            return null;
-          }
           valid = this.next_month();
           break;
         case "YEARLY":
-          if (this.has_invalid_bysetpos(53)) {
-            return null;
-          }
           this.next_year();
           break;
         default:
@@ -417,7 +424,11 @@ ICAL.RecurIterator = (function() {
     get_max_number_of_possible_byday_values: function get_number_of_possible_byday_values(days_in_timeslice) {
       var self = this;
       var reducer = function(acc, value) {
-        return acc + Math.floor(days_in_timeslice / self.ruleDayOfWeek(value)[0]);
+        var whatNumberOfDay = self.ruleDayOfWeek(value)[0];
+        if (whatNumberOfDay === 0) {
+          return days_in_timeslice;
+        }
+        return acc + 1
       };
       return this.by_data.BYDAY.reduce(reducer, 0);
     },
@@ -432,6 +443,10 @@ ICAL.RecurIterator = (function() {
     },
 
     has_invalid_bysetpos: function has_invalid_bysetpos(days_in_timeslice) {
+      // days_in_timeslice math:
+      // there are at most 5 of any given day in a month, and 53 of any given day in a year
+      // i.e. you can't have 6 mondays in one month, or 54 tuesday in a year.
+
       try { 
         if (!this.by_data.BYDAY || this.by_data.BYDAY.length < 1) {
           return false;

--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -327,6 +327,16 @@ ICAL.RecurIterator = (function() {
         return null;
       }
 
+      // if there are no possible valid events return null.
+      try {
+        if (this.has_invalid_bysetpos()) {
+          return null;
+        }
+      } catch (err) {
+       // do nothing.
+      }
+
+
       if (this.occurrence_number == 0 && this.last.compare(this.dtstart) >= 0) {
         // First of all, give the instance that was initialized
         this.occurrence_number++;
@@ -407,6 +417,39 @@ ICAL.RecurIterator = (function() {
 
     increment_hour: function increment_hour(inc) {
       this.increment_generic(inc, "hour", 24, "monthday");
+    },
+
+    get_number_of_days_in_frequency: function get_number_of_days_in_frequency() {
+      // There is a maximum of 53 of any given day in a year,
+      // and 5 in a month. i.e. there cannot be more than 5 Sundays in 1 month.
+      return this.rule.freq === "YEARLY" ? 53 : 5;
+    },
+
+    get_max_number_of_possible_byday_values: function get_number_of_possible_byday_values() {
+      var self = this;
+      var reducer = function(acc, value) {
+        return acc + Math.floor(self.get_number_of_days_in_frequency() / self.ruleDayOfWeek(value)[0]);
+      };
+      return this.by_data.BYDAY.reduce(reducer, 0);
+    },
+
+    has_invalid_bysetpos: function has_invalid_bysetpos() {
+      if (!this.by_data.BYDAY || this.by_data.BYDAY.length < 1) {
+        return false;
+      }
+
+      if (!this.by_data.BYSETPOS || this.by_data.BYSETPOS.length < 1) {
+        return false;
+      }
+
+      var max_number_of_possible_days = this.get_max_number_of_possible_byday_values();
+      var checker = function(acc, value) {
+        if (acc) {
+          return acc;
+        }
+        return value > max_number_of_possible_days;
+      };
+      return this.by_data.BYSETPOS.reduce(checker, false);
     },
 
     next_day: function next_day() {

--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -327,10 +327,6 @@ ICAL.RecurIterator = (function() {
         return null;
       }
 
-      if (this.has_invalid_bysetpos()) {
-        return null;
-      }
-
       if (this.occurrence_number == 0 && this.last.compare(this.dtstart) >= 0) {
         // First of all, give the instance that was initialized
         this.occurrence_number++;

--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -426,7 +426,7 @@ ICAL.RecurIterator = (function() {
       var reducer = function(acc, value) {
         var whatNumberOfDay = self.ruleDayOfWeek(value)[0];
         if (whatNumberOfDay === 0) {
-          return days_in_timeslice;
+          return acc + days_in_timeslice;
         }
         return acc + 1
       };

--- a/lib/ical/recur_iterator.js
+++ b/lib/ical/recur_iterator.js
@@ -213,12 +213,14 @@ ICAL.RecurIterator = (function() {
 
       // I've turned this off because there's weird behaviour where the recur iterator completely ignores BYSETPOS :thinking:
       // if (this.rule.freq == "YEARLY") {
+      // // there are at most 5 of any given day in a month, and 53 of any given day in a year
       //   if (this.has_invalid_bysetpos(53)) {
       //     throw new Error("Yearly BYSETPOS value larger than max count of viable events");
       //   }
       // }
 
       if (this.rule.freq == "MONTHLY") {
+        // there are at most 5 of any given day in a month, and 53 of any given day in a year
         if (this.has_invalid_bysetpos(5)) {
           throw new Error("Monthly BYSETPOS value larger than max count of viable events");
         }

--- a/test/performance/rrule_test.js
+++ b/test/performance/rrule_test.js
@@ -43,7 +43,8 @@ perfCompareSuite('rrule', function(perf, ICAL) {
 
     // Apple iCal rules
     "FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=3",
-    "FREQ=MONTHLY;BYDAY=SA,SU;BYMONTH=11;BYSETPOS=-1"
+    "FREQ=MONTHLY;BYDAY=SA,SU;BYMONTH=11;BYSETPOS=-1",
+    "FREQ=MONTHLY;BYDAY=3MO,3TU;BYSETPOS=3"
 
   ].forEach(function(rulestring) {
     perf.test(rulestring, function() {

--- a/test/recur_iterator_test.js
+++ b/test/recur_iterator_test.js
@@ -54,7 +54,6 @@ suite('recur_iterator', function() {
     if (includeTime) {
       list.unshift(start);
       list.push(end);
-
     } else {
       list.unshift(createDay(start));
       list.push(createDay(end));
@@ -1216,7 +1215,7 @@ suite('recur_iterator', function() {
             "2013-05-21",
           ],
           max: 6,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=1MO,1TU,1WE,1TH,1FR,1SA,1SU;BYSETPOS=8', {
           dates: [
             "2013-01-15",
@@ -1227,7 +1226,7 @@ suite('recur_iterator', function() {
             "2013-05-21",
           ],
           max: 6,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=4MO,3TU,2WE,1TH,FR;BYSETPOS=10', {
           dates: [
             "2013-01-15",
@@ -1238,7 +1237,7 @@ suite('recur_iterator', function() {
             "2013-05-21",
           ],
           max: 6,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=MO;BYSETPOS=6', {
           dates: [
             "2013-01-15",
@@ -1249,7 +1248,7 @@ suite('recur_iterator', function() {
             "2013-05-21",
           ],
           max: 6,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=1MO;BYSETPOS=6', {
           dates: [
             "2013-01-15",
@@ -1260,7 +1259,7 @@ suite('recur_iterator', function() {
             "2013-05-21",
           ],
           max: 6,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=1MO,TU;BYSETPOS=8', {
           dates: [
             "2013-01-15",
@@ -1271,7 +1270,7 @@ suite('recur_iterator', function() {
             "2013-05-21",
           ],
           max: 6,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=WE,2TH,3FR;BYSETPOS=8', {
           dates: [
             "2013-01-15",
@@ -1282,7 +1281,7 @@ suite('recur_iterator', function() {
             "2013-05-21",
           ],
           max: 6,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=2MO,TU,WE,4TH;BYSETPOS=20', {
           dates: [
             "2013-01-15",
@@ -1293,7 +1292,7 @@ suite('recur_iterator', function() {
             "2013-05-21",
           ],
           max: 6,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=2MO,TU,WE,5TH;BYSETPOS=13', {
           dates: [
             "2013-01-15",
@@ -1304,7 +1303,7 @@ suite('recur_iterator', function() {
             "2013-05-21",
           ],
           max: 6,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=MO,-3TU;BYSETPOS=7', {
           dates: [
             "2013-01-15",
@@ -1315,7 +1314,7 @@ suite('recur_iterator', function() {
             "2013-05-21",
           ],
           max: 6,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=MO,-1TU,-4WE,5TH;BYSETPOS=10', {
           dates: [
             "2013-01-15",
@@ -1326,7 +1325,7 @@ suite('recur_iterator', function() {
             "2013-05-21",
           ],
           max: 6,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
       });
       suite('valid multiple BYSETPOS values', () => {
         testRRULE('FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR,SA,SU;BYSETPOS=10,25,31', {
@@ -1496,7 +1495,7 @@ suite('recur_iterator', function() {
             "2013-08-31",
           ],
           max: 10,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=1MO,1TU,1WE,1TH,1FR,1SA,1SU;BYSETPOS=1,3,6,42', {
           dates: [
             "2013-06-01",
@@ -1511,7 +1510,7 @@ suite('recur_iterator', function() {
             "2013-09-01",
           ],
           max: 10,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=4MO,3TU,2WE,1TH,FR;BYSETPOS=1,4,8,42', {
           dates: [
             "2013-05-27",
@@ -1526,7 +1525,7 @@ suite('recur_iterator', function() {
             "2013-08-26",
           ],
           max: 10,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=MO;BYSETPOS=1,3,5,42', {
           dates: [
             "2013-06-03",
@@ -1541,7 +1540,7 @@ suite('recur_iterator', function() {
             "2013-09-30",
           ],
           max: 10,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=1MO;BYSETPOS=1,42', {
           dates: [
             "2013-06-03",
@@ -1556,7 +1555,7 @@ suite('recur_iterator', function() {
             "2014-03-03",
           ],
           max: 10,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=1MO,TU;BYSETPOS=1,2,3,42', {
           dates: [
             "2013-06-03",
@@ -1571,7 +1570,7 @@ suite('recur_iterator', function() {
             "2013-09-02",
           ],
           max: 10,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=WE,2TH,3FR;BYSETPOS=2,4,7,42', {
           dates: [
             "2013-05-29",
@@ -1586,7 +1585,7 @@ suite('recur_iterator', function() {
             "2013-09-18",
           ],
           max: 10,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=2MO,TU,WE,4TH;BYSETPOS=4,8,12,42', {
           dates: [
             "2013-05-22",
@@ -1601,7 +1600,7 @@ suite('recur_iterator', function() {
             "2013-09-24",
           ],
           max: 10,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=2MO,TU,WE,5TH;BYSETPOS=3,9,10,42', {
           dates: [
             "2013-05-28",
@@ -1616,7 +1615,7 @@ suite('recur_iterator', function() {
             "2013-08-29",
           ],
           max: 10,
-        });
+        }, 'Monthly BYSETPOS value larger than max count of viable events');
         testRRULEWithError('FREQ=MONTHLY;BYDAY=MO,-3TU;BYSETPOS=2,4,5,42', {
           dates: [
             "2013-05-27",


### PR DESCRIPTION
TL;DR of the problem:

In an iCal feed you can define a recurring schedule and also say "pick every 3rd event of each month". However, this doesn't work if you also say "This event happens on the third sunday of each month". You suddenly have conflicting criteria, the worker starts looking for the third event of each month, when each month only has 1 event. Currently if the worker encounters this it will spend a very very very very very long time generating events for a month and then checking if any events of that month meet the criteria. It does have a hard-coded kill-loop value I believe but it isn't reached in a timely manner.